### PR TITLE
Move to drush-ops/drush-launcher on Github.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ deploy:
     - drush.phar
     - drush.version
   on:
-    repo: webflo/drush-shim
+    repo: drush-ops/drush-launcher
     tags: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Drush Shim
+# Drush Launcher
 
 A small wrapper around Drush for your global $PATH.
 
@@ -9,8 +9,8 @@ A site local Drush is the easiest solution to avoid dependency issues and your p
 ## Installation
 
 ```Shell
-# Download latest stable release using the code below or browse to https://github.com/webflo/drush-shim/releases/latest.
-wget https://github.com/webflo/drush-shim/releases/download/0.2.7/drush.phar
+# Download latest stable release using the code below or browse to https://github.com/drush-ops/drush-launcher/releases/latest.
+wget https://github.com/drush-ops/drush-launcher/releases/download/0.2.7/drush.phar
 
 # Rename to `drush` instead of `php drush.phar`. Destination can be anywhere on $PATH. 
 chmod +x drush.phar

--- a/bin/drush.php
+++ b/bin/drush.php
@@ -83,7 +83,7 @@ if ($SELF_UPDATE) {
   }
   $updater = new Updater(null, false);
   $updater->setStrategy(Updater::STRATEGY_GITHUB);
-  $updater->getStrategy()->setPackageName('webflo/drush-shim');
+  $updater->getStrategy()->setPackageName('drush-ops/drush-launcher');
   $updater->getStrategy()->setPharName('drush.phar');
   $updater->getStrategy()->setCurrentLocalVersion($DRUSH_SHIM_VERSION);
   try {
@@ -91,7 +91,7 @@ if ($SELF_UPDATE) {
     echo $result ? "Updated!\n" : "No update needed!\n";
     exit(0);
   } catch (\Exception $e) {
-    echo "Automatic update failed, please download the latest version from https://github.com/webflo/drush-shim/releases\n";
+    echo "Automatic update failed, please download the latest version from https://github.com/drush-ops/drush-launcher/releases\n";
     exit(1);
   }
 }

--- a/bin/drush.php
+++ b/bin/drush.php
@@ -83,7 +83,7 @@ if ($SELF_UPDATE) {
   }
   $updater = new Updater(null, false);
   $updater->setStrategy(Updater::STRATEGY_GITHUB);
-  $updater->getStrategy()->setPackageName('drush-ops/drush-launcher');
+  $updater->getStrategy()->setPackageName('drush/drush-launcher');
   $updater->getStrategy()->setPharName('drush.phar');
   $updater->getStrategy()->setCurrentLocalVersion($DRUSH_SHIM_VERSION);
   try {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "webflo/drush-shim",
+    "name": "drush/drush-launcher",
     "description": "Provides a drush executable for your global PATH",
     "license": "GPL-2.0+",
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ef26bab0cd3759b92bd88b37b2ece6f",
+    "content-hash": "0dc3bedb0c5b16a54bc64abd0c2bb2cd",
     "packages": [
         {
             "name": "padraic/humbug_get_contents",


### PR DESCRIPTION
I propose we move this project to drush-ops and rename to Drush Launcher. Here are some needed code changes that can happen at same time as the repo rename. I hope webflo keeps going as maintainer.