### PR TITLE
Set root via PWD rather than drush_set_option(). Also remove --local.

### DIFF
--- a/bin/drush.php
+++ b/bin/drush.php
@@ -117,6 +117,8 @@ if ($DEBUG) {
 }
 
 chdir($drupalRoot);
+// This is required to fool drush_locate_root() into using $drupalRoot.
+$_SERVER['PWD'] = $drupalRoot;
 
 if (file_exists($drupalRoot . '/autoload.php')) {
   require_once $drupalRoot . '/autoload.php';
@@ -132,8 +134,5 @@ if (!file_exists($drupalFinder->getVendorDir() . '/drush/drush/includes/prefligh
   exit(1);
 }
 require_once $drupalFinder->getVendorDir() . '/drush/drush/includes/preflight.inc';
-require_once $drupalFinder->getVendorDir() . '/drush/drush/includes/context.inc';
 
-drush_set_option('root', $drupalRoot);
-drush_set_option('local', TRUE);
 exit(drush_main());


### PR DESCRIPTION
This is required for Drush 9 compatibility, since drush_set_option() is nearly gone. This code is backwards compatible. Sites still running a site-local Drush8 will still have a functional launcher after this is merged.

`drush_set_option('local', true)` is removed since it was bothering folks. See https://github.com/drush-ops/drush/issues/2917