### PR TITLE
Fix fallback docs and logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ When a site-local Drush is not found, this launcher usually throws a helpful err
 You may avoid the error and instead hand off execution to a global Drush (any version)
 by doing *either* of:
 
-1. Specify an environment variable: `DRUSH_LAUNCHER_FALLBACK=/path/to/drush`
+1. Export an environment variable: `export DRUSH_LAUNCHER_FALLBACK=/path/to/drush`
 1. Specify an option: `--fallback=/path/to/drush`
 
 ## License

--- a/bin/drush.php
+++ b/bin/drush.php
@@ -35,7 +35,7 @@ $VERSION = FALSE;
 $VERSION_LAUNCHER = FALSE;
 $DRUSH_VERSION = NULL;
 $SELF_UPDATE = FALSE;
-$FALLBACK = FALSE;
+$FALLBACK = getenv('DRUSH_LAUNCHER_FALLBACK') ?: FALSE;
 
 foreach ($_SERVER['argv'] as $arg) {
   // If a variable to set was indicated on the
@@ -68,9 +68,6 @@ foreach ($_SERVER['argv'] as $arg) {
     }
     if (substr($arg, 0, 11) == "--fallback=") {
       $FALLBACK = substr($arg, 11);
-    }
-    elseif (getenv('DRUSH_LAUNCHER_FALLBACK')) {
-      $FALLBACK = getenv('DRUSH_LAUNCHER_FALLBACK');
     }
   }
 }


### PR DESCRIPTION
I tried today the Drush launcher with a Drupal 7 project and, after finding https://github.com/drush-ops/drush-launcher/pull/39 and updating it, I did the following:

```
[juampy@carboncete ~]$ cd /path/to/drupal7
[juampy@carboncete /path/to/drupal7 (master)]$ DRUSH_LAUNCHER_FALLBACK=/usr/share/drush/drush
[juampy@carboncete /path/to/drupal7 (master)]$ drush st
The Drush launcher could not find a Drupal site to operate on. Please do *one* of the following:
  - Navigate to any where within your Drupal project and try again.
  - Add --root=/path/to/drupal so Drush knows where your site is located.
```

After debugging the launcher, I found out that `getenv()` was returning false. I fixed this by exporting the variable instead of just setting it.

This pull request does two things:
1. Adjust the docs so the fallback variable is exported.
2. Move the fallback via environment variable logic out of the arg loop as otherwise it would be unnecessarily evaluated more than once if there are several unexpected arguments. The new logic also allows having an environment variable but overriding it via an option, which is a practice that I have seen in other projects.