### PR TITLE
Fix #32, #48. Remove automatic --local for drush8 projects.

### DIFF
--- a/bin/drush.php
+++ b/bin/drush.php
@@ -146,7 +146,6 @@ if ($drupalFinder->locateRoot($ROOT)) {
     require_once $drupalFinder->getVendorDir() . '/drush/drush/includes/preflight.inc';
     require_once $drupalFinder->getVendorDir() . '/drush/drush/includes/context.inc';
     drush_set_option('root', $drupalRoot);
-    drush_set_option('local', TRUE);
     exit(drush_main());
   }
   if (!$DRUSH_VERSION && !$FALLBACK) {


### PR DESCRIPTION
The launcher adds --local option for Drush8 sites. This has confused folks in #32 and #48. Lets remove it from Launcher. Folks who want that can configure their drush8 accordingly.