### PR TITLE
Updated README.md for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,16 @@ However, it is inconvenient to type `vendor/bin/drush` in order to execute Drush
 
     ```Shell
     sudo mv drush.phar /usr/local/bin/drush
+    ```    
     
-    # In some setups it is better to move it to ~/bin/drush (for example if you have installed drush via 
-    # composer global    require drush/drush to ~/.composer/vendor/bin and this project is on your path 
-    # before /usr/local/bin.
-    mv drush.phar /usr/local/bin/drush
+ In some setups it is better to move it to `~/bin/drush` (for example if you have installed drush via 
+ `composer global require drush/drush` to `~/.composer/vendor/bin` and this project is on your path 
+ before `/usr/local/bin`.
+    
+    ```Shell
+    mv drush.phar ~/bin/drush
     ```
+    
 The Drush Launcher Phar is able to self update to the latest release.
 
 ```Shell

--- a/README.md
+++ b/README.md
@@ -22,16 +22,17 @@ However, it is inconvenient to type `vendor/bin/drush` in order to execute Drush
     ```Shell
     wget -O drush.phar https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
     ```
+
 1. Make downloaded file executable: `chmod +x drush.phar`
 1. Move drush.phar to a location listed in your `$PATH`, rename to `drush`: 
 
     ```Shell
-    sudo mv drush.phar /usr/local/bin/drush
-    ```
-    
- In some setups it is better to move it to `~/bin/drush` (for example if you have installed drush via 
- `composer global require drush/drush` to `~/.composer/vendor/bin` and this project is on your path 
- before `/usr/local/bin`.
+    sudo mv drush.phar /usr/local/bin/drush```
+    
+
+  In some setups it is better to move it to `~/bin/drush` (for example if you have installed drush via 
+  `composer global require drush/drush` to `~/.composer/vendor/bin` and this project is on your path 
+  before `/usr/local/bin`.
     
   ```Shell
   mv drush.phar ~/bin/drush

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ However, it is inconvenient to type `vendor/bin/drush` in order to execute Drush
 
     ```Shell
     sudo mv drush.phar /usr/local/bin/drush
+    
+    # In some setups it is better to move it to ~/bin/drush (for example if you have installed drush via 
+    # composer global    require drush/drush to ~/.composer/vendor/bin and this project is on your path 
+    # before /usr/local/bin.
+    mv drush.phar /usr/local/bin/drush
     ```
 The Drush Launcher Phar is able to self update to the latest release.
 

--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ However, it is inconvenient to type `vendor/bin/drush` in order to execute Drush
 
     ```Shell
     sudo mv drush.phar /usr/local/bin/drush
-    ```    
+    ```
     
  In some setups it is better to move it to `~/bin/drush` (for example if you have installed drush via 
  `composer global require drush/drush` to `~/.composer/vendor/bin` and this project is on your path 
  before `/usr/local/bin`.
     
-    ```Shell
-    mv drush.phar ~/bin/drush
-    ```
+  ```Shell
+  mv drush.phar ~/bin/drush
+  ```
     
 The Drush Launcher Phar is able to self update to the latest release.
 
-```Shell
-    drush self-update
-```
+  ```Shell
+  drush self-update
+  ```
 
 ## Installation - Homebrew
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ However, it is inconvenient to type `vendor/bin/drush` in order to execute Drush
 1. Make downloaded file executable: `chmod +x drush.phar`
 1. Move drush.phar to a location listed in your `$PATH`, rename to `drush`: 
 
+    Default
     ```Shell
-    sudo mv drush.phar /usr/local/bin/drush```
-    
-
-  In some setups it is better to move it to `~/bin/drush` (for example if you have installed drush via 
-  `composer global require drush/drush` to `~/.composer/vendor/bin` and this project is on your path 
-  before `/usr/local/bin`.
+    sudo mv drush.phar /usr/local/bin/drush
+    ```
     
-  ```Shell
-  mv drush.phar ~/bin/drush
-  ```
+    In some setups it is better to move it to `~/bin/drush` (for example if you have installed drush via 
+    `composer global require drush/drush` to `~/.composer/vendor/bin` and this project is on your path 
+    before `/usr/local/bin`.
+
+    ```Shell
+    mv drush.phar ~/bin/drush
+    ```
     
 The Drush Launcher Phar is able to self update to the latest release.
 


### PR DESCRIPTION
Here /usr/local/bin/drush was not used because I have ~/.composer/vendor/bin on my PATH and it is evaluated before /usr/local/bin thats why my global drush in ~/.composer/vendor/bin/drush always is called instead of the launcher at /usr/local/bin/drush - the solution was to move the launcher to ~/bin