### PR TITLE
Modify batch file command to support directory spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ However, it is inconvenient to type `vendor/bin/drush` in order to execute Drush
     
 1. Windows users: create a drush.bat file in the same folder as drush.phar with the following lines. This gets around the problem where Windows does not know that .phar files are associated with `php`:
    
-   @echo off
-   php %~dp0\drush.phar %*
+    ``` Bat
+    @echo off
+    php "%~dp0\drush.phar" %*
+    ```
 
 ## Update
 


### PR DESCRIPTION
The batch file described in the documentation did not work for me initially, since I added my drush.phar file in "C:\Program Files\Drush". 

This path contains a space that is not escaped, resulting in the command to fail.

Adding quotes around the entire path fixes this problem.