### PR TITLE
Upgrade Box (Phar packager)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/drush.phar
+/*.phar
 /drush.version
 /vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ php:
   - 7.1
 
 before_script:
-  - curl -LSs https://box-project.github.io/box2/installer.php | php
+  - composer box-install
   - composer install --no-interaction --no-progress
 
 script:
-  - ./box.phar build
+  - composer box-compile
   - sha1sum drush.phar > drush.version
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 sudo: false
 
 php:
-  - 7.1
+  - 7.4
 
 before_script:
   - composer box-install

--- a/box.json
+++ b/box.json
@@ -1,6 +1,10 @@
 {
   "main": "bin/drush.php",
   "output": "drush.phar",
+  "compactors": [
+    "KevinGH\\Box\\Compactor\\Php",
+    "KevinGH\\Box\\Compactor\\Json"
+  ],
   "finder": [
     {
       "name": "*.php",
@@ -11,6 +15,5 @@
     }
   ],
   "git-commit": "git-commit",
-  "git-version": "git-version",
-  "stub": true
+  "git-version": "git-version"
 }

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,13 @@
     ],
     "bin": [
         "bin/drush"
-    ]
+    ],
+    "scripts": {
+        "box-install": [
+            "curl -O -L https://github.com/box-project/box/releases/download/3.8.5/box.phar"
+        ],
+        "box-compile": [
+            "php box.phar compile"
+        ]
+    }
 }


### PR DESCRIPTION
This makes several improvements to the packaging system, to improve both the contributor and end-user experience:
- Upgrade from the abandoned box2 project to the newer box project. Not only is this a maintained version, but it brings several improvements, such as automatically disabling phar.readonly for contributors building locally.
- Add config options (available in the new box version) that shrink the generated phar file by 25%
- Add Composer scripts so that drush-launcher contributors can easily build the phar locally
- Gitignore the generated drush.phar