### PR TITLE
Use a tagged release of phar-updater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "webflo/drupal-finder": "^1.0",
         "webmozart/path-util": "^2.3",
         "composer/xdebug-handler": "^1.0",
-        "laravel-zero/phar-updater": "dev-main"
+        "laravel-zero/phar-updater": "^1.1"
     },
     "conflict": {
         "drush/drush": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ff58d6fc2c139f57d57a61fd4768bce",
+    "content-hash": "5be7823442a7b313104081fd66f1c343",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -72,16 +72,16 @@
         },
         {
             "name": "laravel-zero/phar-updater",
-            "version": "dev-main",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel-zero/phar-updater.git",
-                "reference": "47610b5b91d1beb9ec314aeecdda13eb0df0d8e5"
+                "reference": "ac583f0983f91df9ca18c31ef6fd44dd51820495"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel-zero/phar-updater/zipball/47610b5b91d1beb9ec314aeecdda13eb0df0d8e5",
-                "reference": "47610b5b91d1beb9ec314aeecdda13eb0df0d8e5",
+                "url": "https://api.github.com/repos/laravel-zero/phar-updater/zipball/ac583f0983f91df9ca18c31ef6fd44dd51820495",
+                "reference": "ac583f0983f91df9ca18c31ef6fd44dd51820495",
                 "shasum": ""
             },
             "require": {
@@ -92,10 +92,9 @@
             },
             "require-dev": {
                 "ext-json": "*",
-                "phpstan/phpstan": "^0.12.81",
+                "phpstan/phpstan": "^0.12.85",
                 "phpunit/phpunit": "^9.4"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -122,9 +121,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel-zero/phar-updater/issues",
-                "source": "https://github.com/laravel-zero/phar-updater/tree/main"
+                "source": "https://github.com/laravel-zero/phar-updater/tree/v1.1.1"
             },
-            "time": "2021-03-09T09:35:34+00:00"
+            "time": "2021-08-03T08:29:40+00:00"
         },
         {
             "name": "psr/log",
@@ -411,12 +410,10 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "laravel-zero/phar-updater": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Currently, the version of phar-updater is set to `dev-main` and this causes problems in some places. I just faced an issue using this as a build dependency on platform.sh and I couldn't change the minimum stability flag. I see that the package has recent tagged releases and this PR uses the latest one.

| Production Changes        | From    | To     | Compare |
| ------------------------ | -------| ------ | -----------|
| laravel-zero/phar-updater | 47610b5 | v1.1.1 | https://github.com/laravel-zero/phar-updater/compare/47610b5...v1.1.1 |
